### PR TITLE
Fix UX reviewer integration across framework

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,12 +23,12 @@ The swarm is a set of specialized Claude Code agents that collaborate through an
                        │    │    │        │
               dispatch │    │    │        │ monitor
                        │    │    │        │ (check-agents.sh)
-                 ┌─────▼┐ ┌▼────▼─┐  ┌───┴──────┐
-                 │Resear-│ │Worker │  │Reviewer  │
-                 │cher   │ │(code) │  │(read-    │
-                 │(read- │ │       │  │ only)    │
-                 │ only) │ │       │  │          │
-                 └───────┘ └───┬───┘  └──────────┘
+                 ┌─────▼┐ ┌▼────▼─┐  ┌───┴──────┐  ┌──────────┐
+                 │Resear-│ │Worker │  │Reviewer  │  │UX        │
+                 │cher   │ │(code) │  │(read-    │  │Reviewer  │
+                 │(read- │ │       │  │ only)    │  │(read-    │
+                 │ only) │ │       │  │          │  │ only)    │
+                 └───────┘ └───┬───┘  └──────────┘  └──────────┘
                                │
                           opens PR/MR
                                │
@@ -38,7 +38,7 @@ The swarm is a set of specialized Claude Code agents that collaborate through an
                     └─────────────────────────────┘
 ```
 
-## The Four Roles
+## The Five Roles
 
 | Role | Reads | Writes | Isolation | Purpose |
 |------|-------|--------|-----------|---------|

--- a/template/.claude/agents/reviewer.md
+++ b/template/.claude/agents/reviewer.md
@@ -102,7 +102,7 @@ Post on the issue using your tracker's comment command:
 
 Summary: [1-2 sentences on what the PR does well]
 
-<!-- CUSTOMIZE: @your-github-username --> — ready for your review and merge.
+<!-- CUSTOMIZE: @your-username --> — ready for your review and merge.
 ```
 
 **Recommends Changes:**
@@ -121,7 +121,7 @@ Issues:
 Suggested fixes:
 - [Actionable fix for each issue]
 
-<!-- CUSTOMIZE: @your-github-username --> — needs revision before merge.
+<!-- CUSTOMIZE: @your-username --> — needs revision before merge.
 ```
 
 ## Guidelines

--- a/template/scripts/check-agents.sh
+++ b/template/scripts/check-agents.sh
@@ -48,7 +48,7 @@ desktop_notify() {
 # Discover all agent windows in the swarm session
 list_agent_windows() {
     tmux list-windows -t swarm -F '#W' 2>/dev/null \
-        | grep -E '^(worker|researcher|reviewer)-' \
+        | grep -E '^(worker|researcher|ux-reviewer|reviewer)-' \
         || true
 }
 


### PR DESCRIPTION
## Summary
- **check-agents.sh:** Added `ux-reviewer` to the window discovery regex (before `reviewer` to prevent false prefix match)
- **architecture.md:** Updated heading from "Four Roles" to "Five Roles" and added UX Reviewer to the ASCII diagram
- **reviewer.md:** Normalized `@your-github-username` to `@your-username` for consistency with ux-reviewer.md

## How to verify
1. Review the regex in `template/scripts/check-agents.sh` line 51 — `ux-reviewer` must appear before `reviewer` in the alternation
2. Check `docs/architecture.md` heading says "Five Roles" and the ASCII diagram includes a UX Reviewer box
3. Confirm both `reviewer.md` and `ux-reviewer.md` use `@your-username` consistently

## Out of scope
- No other files reference the old "Four Roles" wording or the old `@your-github-username` pattern

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)