### PR TITLE
Add complete orchestrator permissions to settings.local.json

### DIFF
--- a/template/.claude/settings.local.json
+++ b/template/.claude/settings.local.json
@@ -1,0 +1,24 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh label:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh project:*)",
+      "Bash(gh api:*)",
+      "Bash(gh repo:*)",
+      "Bash(tmux:*)",
+      "Bash(cat:*)",
+      "Bash(mkdir:*)",
+      "Bash(touch:*)",
+      "Bash(sleep:*)",
+      "Bash(osascript:*)",
+      "Bash(rm:*)",
+      "Bash(find:*)",
+      "Bash(grep:*)",
+      "Bash(ls:*)",
+      "Bash(echo:*)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Creates `template/.claude/settings.local.json` with all permissions the orchestrator needs to run without interactive prompts
- Adds missing permissions: `tmux`, `cat`, `mkdir`, `touch`, `sleep`, `osascript`, `rm`
- Does not include redundant `Bash(git fetch:*)` or `Bash(git pull:*)` entries since `Bash(git:*)` covers all git subcommands

## Why

Without these permissions, every `tmux` command (and others) triggers an interactive permission prompt, making the swarm unusable for new users following QUICKSTART. This was the #1 blocker.

## How to verify

1. Validate JSON: `python3 -m json.tool template/.claude/settings.local.json`
2. Confirm all 7 missing commands from the issue are present: `tmux`, `cat`, `mkdir`, `touch`, `sleep`, `osascript`, `rm`
3. Confirm no redundant `git fetch` or `git pull` entries exist
4. Confirm `Bash(git:*)` is present as the single git wildcard

## Out of scope

- The inline JSON examples in `QUICKSTART.md` and `docs/customization-guide.md` still show a slightly different permission set (they include project-specific examples like `npm test`). These could be updated in a follow-up to stay consistent with the template file.

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)