### PR TITLE
Improve onboarding docs for new users

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -5,7 +5,8 @@ Get the swarm running in 5 minutes.
 ## Prerequisites
 
 - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated
-- [tmux](https://github.com/tmux/tmux) installed
+- [tmux](https://github.com/tmux/tmux) installed (1.8+ required — `check-agents.sh` uses `capture-pane -p -S` which requires 1.8)
+- **Windows users:** tmux is not available natively on Windows. Use [WSL 2](https://learn.microsoft.com/en-us/windows/wsl/install) to run the swarm
 - Git
 - An issue tracker CLI for your platform:
   - GitHub: [gh](https://cli.github.com/)
@@ -102,9 +103,10 @@ Edit `.claude/settings.local.json` and add your test runner, linter, and any oth
 
 ### 7. Launch the swarm
 
+**Important:** You must run this from the root of your target repo (where `.claude/` lives).
+
 ```bash
-cd /path/to/your-repo
-claude --agent orchestrator
+cd /path/to/your-repo && claude --agent orchestrator
 ```
 
 Tell it: **"Work on open issues"**
@@ -118,6 +120,55 @@ The orchestrator will:
 6. Label issues `ready-to-merge` when done
 
 You check your issue tracker, review the PRs, and merge when satisfied.
+
+> **About `--dangerously-skip-permissions`:** When the orchestrator dispatches worker and researcher agents, it uses `--dangerously-skip-permissions` so those agents can run without interactive permission prompts. This is safe when combined with the `settings.local.json` allowlist (Step 6), which limits exactly which commands agents can run. Without this flag, each agent would pause and ask for permission on every bash command, making autonomous operation impossible.
+
+## What You'll See (First 30 Seconds)
+
+After launching, the orchestrator will begin talking through its plan. Here's roughly what the first 30 seconds look like:
+
+```
+$ cd ~/projects/my-repo && claude --agent orchestrator
+
+╭──────────────────────────────────────────╮
+│ ✻ Welcome to Claude Code                 │
+│   /help for help                         │
+╰──────────────────────────────────────────╯
+
+> Work on open issues
+
+● Reading CLAUDE.md for project context...
+● Fetching open issues from tracker...
+● Found 5 open issues. Triaging by priority...
+● Setting up tmux session "swarm"...
+● Dispatching researcher-01 to investigate issue #12 (P0)...
+● Dispatching researcher-02 to investigate issue #15 (P1)...
+```
+
+You'll see the orchestrator create tmux windows for each agent. You can watch all agents in real time with `tmux attach -t swarm` and switch between windows with `Ctrl-b n` (next) and `Ctrl-b p` (previous).
+
+## Stopping the Swarm
+
+To stop the swarm gracefully:
+
+1. **Tell the orchestrator to stop:** Type in its window (or at the prompt):
+   ```
+   Write HANDOFF.md and stop. Wrap up any in-flight tasks.
+   ```
+   The orchestrator will write a `tasks/HANDOFF.md` summarizing in-flight work, then exit.
+
+2. **Kill the tmux session** to clean up remaining windows:
+   ```bash
+   tmux kill-session -t swarm
+   ```
+
+3. **Clean up worktrees** (optional — do this after merging any open PRs):
+   ```bash
+   git worktree list          # see active worktrees
+   git worktree remove wt-01  # remove a finished worktree
+   ```
+
+Next time you launch the swarm, the orchestrator will read `HANDOFF.md` to resume where it left off.
 
 ## What to Expect
 

--- a/README.md
+++ b/README.md
@@ -131,9 +131,13 @@ The orchestrator maintains three files in `tasks/`:
 ## Requirements
 
 - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (authenticated)
-- [tmux](https://github.com/tmux/tmux)
+- [tmux](https://github.com/tmux/tmux) (1.8+)
 - Git 2.15+ (worktree support)
 - A tracker CLI: [gh](https://cli.github.com/), [glab](https://gitlab.com/gitlab-org/cli), [linear CLI](https://github.com/linear/linear-cli), [jira-cli](https://github.com/ankitpokhrel/jira-cli), or none (local files)
+
+## Platform Notes
+
+**Windows:** tmux is not available natively on Windows. Use [WSL 2](https://learn.microsoft.com/en-us/windows/wsl/install) (Windows Subsystem for Linux) to run the swarm. All commands in this framework assume a Unix shell.
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,6 +167,20 @@ Session resumption brief. Written by the orchestrator before stopping. Read on n
 - Work outside their assigned scope (workers)
 - Modify files (researchers and reviewers)
 
+### The `--dangerously-skip-permissions` Flag
+
+When the orchestrator dispatches agents into tmux windows, it launches them with `--dangerously-skip-permissions`. This flag tells Claude Code to skip interactive permission prompts, allowing agents to run autonomously without a human approving each command.
+
+**Why it's needed:** Without this flag, every agent would pause and ask "Allow Bash(git status)?" on each command. Since the swarm is designed for unattended operation, this would block the entire pipeline.
+
+**Why it's safe in the swarm context:**
+- The `settings.local.json` allowlist (see [QUICKSTART.md](../QUICKSTART.md) Step 6) restricts exactly which commands agents can run — the flag skips prompts but does NOT bypass the allowlist
+- Workers operate in isolated worktrees, not the main repo
+- Researchers and reviewers are read-only by design
+- No agent can merge to the default branch or deploy
+
+**When to be cautious:** If you add broad permissions (e.g., `Bash(*)`), the flag will allow any command without prompting. Keep your allowlist specific.
+
 ### What only the HUMAN can do
 - Merge PRs/MRs
 - Deploy

--- a/docs/customization-guide.md
+++ b/docs/customization-guide.md
@@ -238,7 +238,7 @@ Claude Code reads `CLAUDE.md` from the repo root at the start of every session. 
 - **Architecture overview** — or a pointer to your architecture docs
 - **Anything agents should avoid** — files not to touch, patterns not to use, known gotchas
 
-You don't need a template for this — just describe your project clearly. If you're using Claude Code to set up the swarm, ask it to generate the `CLAUDE.md` for you based on your repo.
+**If your repo doesn't have a `CLAUDE.md` yet, create one now.** This is the single most impactful step — without it, agents will waste time rediscovering project context or make wrong assumptions. You don't need a template — just describe your project clearly. If you're using Claude Code to set up the swarm, ask it to generate the `CLAUDE.md` for you based on your repo.
 
 **Optional additional docs to reference:**
 


### PR DESCRIPTION
## Summary

- Add **"What You'll See"** section to QUICKSTART.md showing the first 30 seconds of terminal output after launch
- Add **"Stopping the Swarm"** section with graceful shutdown steps (tell orchestrator to stop → kill tmux → clean up worktrees)
- Explain **`--dangerously-skip-permissions`** in both QUICKSTART.md (blockquote after Step 7) and docs/architecture.md (new Safety Model subsection)
- Clarify **Step 7 must run from repo root** — combined `cd && claude` in one code block with a bold note
- Add **Windows/WSL 2** guidance to QUICKSTART prerequisites and README
- Add **minimum tmux version (1.8+)** to README requirements and QUICKSTART prerequisites
- Emphasize **CLAUDE.md creation** in customization guide with a callout for repos that don't have one yet

## Test plan

- [ ] Read through QUICKSTART.md end-to-end — verify all 7 steps flow naturally with the new content
- [ ] Verify the "What You'll See" terminal output looks realistic
- [ ] Verify the "Stopping the Swarm" instructions are actionable
- [ ] Check that `--dangerously-skip-permissions` explanation is clear for a non-developer audience
- [ ] Confirm no links are broken

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)