### PR TITLE
Fix minor polish issues across docs and templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
 .DS_Store
+
+# Ephemeral swarm state (regenerated each session)
+tasks/HANDOFF.md
+
+# Suggested additions for your target repo's .gitignore:
+# tasks/state.json
+# tasks/learnings.jsonl
+# tasks/HANDOFF.md

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ See [QUICKSTART.md](QUICKSTART.md) for a 5-minute setup, or read on for the full
 template/
 ├── .claude/
 │   ├── agents/
-│   │   ├── orchestrator.md    # Coordinates the swarm (~600 lines)
-│   │   ├── researcher.md      # Investigates issues (~90 lines)
-│   │   ├── worker.md          # Implements code changes (~80 lines)
-│   │   ├── reviewer.md        # Evaluates PRs/MRs (~110 lines)
-│   │   └── ux-reviewer.md     # Evaluates frontend UX (~200 lines)
+│   │   ├── orchestrator.md    # Coordinates the swarm
+│   │   ├── researcher.md      # Investigates issues
+│   │   ├── worker.md          # Implements code changes
+│   │   ├── reviewer.md        # Evaluates PRs/MRs
+│   │   └── ux-reviewer.md     # Evaluates frontend UX
 │   └── settings.local.json    # Minimal permission allowlist
 ├── scripts/
 │   └── check-agents.sh        # Tmux monitor (detects completion, errors, stuck agents)

--- a/docs/customization-guide.md
+++ b/docs/customization-guide.md
@@ -7,7 +7,7 @@ Step-by-step guide to adapting the swarm framework for your project.
 Every agent definition has a `## Project Context` section with `<!-- CUSTOMIZE -->` markers. Fill these in for your project:
 
 ```markdown
-- **Repo:** ~/projects/my-app/
+- **Repo:** ~/path/to/your-repo/
 - **Remote URL:** https://github.com/myorg/my-app
 - **Languages:** TypeScript, Go
 - **Test command:** npm test
@@ -15,7 +15,7 @@ Every agent definition has a `## Project Context` section with `<!-- CUSTOMIZE -
 - **Architecture docs:** docs/ARCHITECTURE.md
 - **Coding guidelines:** CLAUDE.md
 - **Default branch:** main
-- **Worktree parent:** ~/projects/ (worktrees live as siblings to your repo)
+- **Worktree parent:** ~/worktrees/ (worktrees live as siblings to your repo)
 ```
 
 Update this section in all five agent files:
@@ -170,6 +170,8 @@ Edit `.claude/settings.local.json` to add permissions for your project's tooling
 
 The template includes minimal git and CLI permissions. Add your project-specific tools:
 
+> **Note:** JSON does not support comments. The `//` lines in the example below are for illustration only — remove them and uncomment only the permissions you need.
+
 ```json
 {
   "permissions": {
@@ -220,8 +222,6 @@ The template includes minimal git and CLI permissions. Add your project-specific
   }
 }
 ```
-
-**Note:** JSON does not support comments. The `//` lines above are for illustration — remove them and uncomment only the permissions you need.
 
 ## Step 6: Create Your `CLAUDE.md`
 

--- a/template/.claude/agents/researcher.md
+++ b/template/.claude/agents/researcher.md
@@ -15,7 +15,7 @@ A worker agent will implement this issue after you. Your comment is the briefing
 
 1. **Do not write code.** Do not create branches, make commits, or open PRs.
 2. **Do not modify any files.** You are read-only.
-3. **Do not deploy or modify production.** You may inspect production environments READ-ONLY (logs, configs, versions, status). You may NEVER run any command that modifies state (no deploy, restart, stop, rm, mv, cp, or redirects like `>` `>>`). If production needs changing, note it in your comment for the human.
+3. **Do not deploy or modify production.** You may inspect production environments READ-ONLY (logs, configs, versions, status). You may NEVER run any command that modifies production state (no deploy, restart, stop, rm, mv, cp to production hosts, or redirects like `>` `>>`). If production needs changing, note it in your comment for the human.
 4. **Post exactly one comment** on the issue with your findings.
 
 ## Project Context

--- a/template/scripts/check-agents.sh
+++ b/template/scripts/check-agents.sh
@@ -52,6 +52,7 @@ list_agent_windows() {
         || true
 }
 
+# macOS ships `md5`, Linux ships `md5sum`. Try macOS first, fall back to Linux.
 content_hash() {
     echo "$1" | md5 2>/dev/null || echo "$1" | md5sum 2>/dev/null | cut -d' ' -f1
 }


### PR DESCRIPTION
## Summary

Fixes 6 small polish issues identified in #5:

- **JSON comment warning** (`docs/customization-guide.md`): Moved the "JSON does not support comments" note to *before* the code block so users see it before copy-pasting invalid JSON
- **Placeholder paths** (`docs/customization-guide.md`): Standardized `~/projects/my-app/` → `~/path/to/your-repo/` for consistency with all other files
- **README line counts** (`README.md`): Removed stale approximate line counts from the tree listing — they were already drifting and add maintenance burden
- **Platform comment** (`template/scripts/check-agents.sh`): Added comment explaining macOS `md5` vs Linux `md5sum` fallback
- **`.gitignore` gaps** (`.gitignore`): Added `tasks/HANDOFF.md` (ephemeral, shouldn't be committed) and suggested `.gitignore` additions for target repos
- **Researcher `cp` restriction** (`template/.claude/agents/researcher.md`): Qualified to "cp to production hosts" — local `cp` in the repo is fine for research

## Out of scope

- `docs/architecture.md` contains one `~/projects/` reference (line 90) but is being changed by PR #6 — left for that PR to address

## How to verify

```bash
# Check JSON warning placement
grep -n "Note.*JSON" docs/customization-guide.md

# Confirm no remaining ~/projects/ outside architecture.md
grep -r "~/projects/" --include="*.md" --include="*.sh" . | grep -v architecture.md

# Verify .gitignore
cat .gitignore
```

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)