### PR TITLE
Extract shared project context and tracker commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ A documentation and template framework for running coordinated Claude Code agent
 template/              # Files users copy into their repos
   .claude/
     agents/            # Agent role definitions (orchestrator, researcher, worker, reviewer, ux-reviewer)
+      _project-context.md  # Shared project context (edited once, read by all agents)
+      _tracker-commands.md # Shared tracker CLI commands (edited once, read by all agents)
     settings.local.json # Permission allowlist template
   scripts/
     check-agents.sh    # Tmux monitor script

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -44,18 +44,13 @@ You don't need a template — just describe your project clearly. If you're usin
 
 ### 3. Fill in Project Context
 
-Open each agent file and update the `<!-- CUSTOMIZE -->` sections:
+Edit the shared project context file — all agents read this automatically:
 
 ```bash
-# Edit all five:
-$EDITOR .claude/agents/orchestrator.md
-$EDITOR .claude/agents/researcher.md
-$EDITOR .claude/agents/worker.md
-$EDITOR .claude/agents/reviewer.md
-$EDITOR .claude/agents/ux-reviewer.md
+$EDITOR .claude/agents/_project-context.md
 ```
 
-At minimum, set in each file:
+At minimum, set:
 - **Repo path** — absolute path to your repo
 - **Languages** — what your project uses
 - **Test command** — how to run tests (e.g., `npm test`, `pytest`)
@@ -63,12 +58,18 @@ At minimum, set in each file:
 
 ### 4. Choose your tracker
 
-In each agent file, uncomment the command block for your issue tracker (GitHub, GitLab, Linear, Jira, or local files) and delete the others.
+Edit the shared tracker commands file — uncomment the section for your platform and delete the rest:
+
+```bash
+$EDITOR .claude/agents/_tracker-commands.md
+```
 
 ### 5. Create status labels
 
+Create the four required status labels in your tracker. See [Customization Guide — Step 3](docs/customization-guide.md#step-3-set-up-labels) for full commands and optional labels.
+
 ```bash
-# GitHub example (adapt for your platform):
+# GitHub quick version:
 gh label create "more-research-needed" --color "FBCA04" --description "Needs investigation"
 gh label create "ready-to-assign" --color "0075CA" --description "Ready for worker agent"
 gh label create "ready-to-merge" --color "0E8A16" --description "Reviewer recommends merge"

--- a/docs/customization-guide.md
+++ b/docs/customization-guide.md
@@ -4,7 +4,7 @@ Step-by-step guide to adapting the swarm framework for your project.
 
 ## Step 1: Project Context
 
-Every agent definition has a `## Project Context` section with `<!-- CUSTOMIZE -->` markers. Fill these in for your project:
+Edit `.claude/agents/_project-context.md` — this is the single source of truth that all five agents read at startup. Fill in the `<!-- CUSTOMIZE -->` fields for your project:
 
 ```markdown
 - **Repo:** ~/path/to/your-repo/
@@ -16,18 +16,14 @@ Every agent definition has a `## Project Context` section with `<!-- CUSTOMIZE -
 - **Coding guidelines:** CLAUDE.md
 - **Default branch:** main
 - **Worktree parent:** ~/worktrees/ (worktrees live as siblings to your repo)
+- **Design system:** src/styles/tokens.css (optional, for ux-reviewer)
 ```
 
-Update this section in all five agent files:
-- `.claude/agents/orchestrator.md`
-- `.claude/agents/researcher.md`
-- `.claude/agents/worker.md`
-- `.claude/agents/reviewer.md`
-- `.claude/agents/ux-reviewer.md`
+You edit this once — all agents pick it up automatically. Each agent file also has a fallback section you can fill in directly if the shared file is missing.
 
 ## Step 2: Choose Your Issue Tracker
 
-Each agent file has a `## Tracker Commands` section with commented-out blocks for different platforms. Uncomment the one you use and delete the rest.
+Edit `.claude/agents/_tracker-commands.md` — uncomment the section matching your platform and delete the rest. All agents read this file for tracker CLI commands.
 
 ### GitHub
 

--- a/template/.claude/agents/_project-context.md
+++ b/template/.claude/agents/_project-context.md
@@ -1,0 +1,15 @@
+# Project Context
+
+<!-- CUSTOMIZE: Fill in these values once. All agents read this file at startup. -->
+
+- **Repo:** `~/path/to/your-repo/`
+- **Remote URL:** `https://github.com/OWNER/REPO` <!-- or GitLab, Bitbucket, etc. -->
+- **Languages:** [your languages, e.g., TypeScript, Python, Go]
+- **Test command:** `[your test command, e.g., npm test, pytest, cargo test, go test ./...]`
+- **CI:** [your CI system, e.g., GitHub Actions, GitLab CI, Jenkins]
+- **Architecture docs:** `[path to architecture docs, e.g., ARCHITECTURE.md]`
+- **Coding guidelines:** `CLAUDE.md` (repo root)
+- **Knowledge base:** `[path to any incident log, findings file, or wiki — optional]`
+- **Worktree parent:** `~/path/to/worktrees/` (worktrees live as siblings to your repo)
+- **Default branch:** `main` <!-- CUSTOMIZE: main or master -->
+- **Design system:** `[path to design tokens, component library, or style guide — for ux-reviewer, optional]`

--- a/template/.claude/agents/_tracker-commands.md
+++ b/template/.claude/agents/_tracker-commands.md
@@ -1,0 +1,47 @@
+# Tracker Commands Reference
+
+<!-- CUSTOMIZE: Uncomment the section matching your tracker and delete the rest. -->
+<!-- All agents read this file so you only configure your tracker once. -->
+
+<!-- === GitHub === -->
+<!-- List issues: gh issue list --state open --json number,title,labels --limit 50 -->
+<!-- Read issue: gh issue view <N> --comments -->
+<!-- Post comment: gh issue comment <N> --body "..." -->
+<!-- Add label: gh issue edit <N> --add-label "ready-to-assign" -->
+<!-- Remove label: gh issue edit <N> --remove-label "more-research-needed" -->
+<!-- Create label: gh label create "ready-to-merge" --color "0E8A16" --description "Reviewer recommends merge" -->
+<!-- List PRs: gh pr list --head <branch> --json number,state -->
+<!-- Open PR: gh pr create --base main --title "..." --body "..." -->
+<!-- Read PR diff: gh pr diff <N> -->
+<!-- Check CI: gh pr checks <N> -->
+<!-- PR fields: state, mergedAt, title, body, number, headRefName, additions, deletions, files, statusCheckRollup -->
+<!-- Note: gh issue view N only shows the body. Use --comments to see research context. -->
+
+<!-- === GitLab === -->
+<!-- List issues: glab issue list --state opened -->
+<!-- Read issue: glab issue view <N> --comments -->
+<!-- Post comment: glab issue note <N> --message "..." -->
+<!-- Add label: glab issue update <N> --label "ready-to-assign" -->
+<!-- Remove label: glab issue update <N> --unlabel "more-research-needed" -->
+<!-- List MRs: glab mr list -->
+<!-- Open MR: glab mr create --target-branch main --title "..." --description "..." -->
+<!-- Read MR diff: glab mr diff <N> -->
+<!-- Check CI: glab ci status -->
+
+<!-- === Linear === -->
+<!-- List issues: linear issue list --team <TEAM> --status "Todo" -->
+<!-- Read issue: linear issue view <ID> -->
+<!-- Post comment: linear comment create --issue <ID> --body "..." -->
+<!-- Update status: linear issue update <ID> --status "In Progress" -->
+
+<!-- === Jira === -->
+<!-- List issues: jira issue list --project <KEY> --status "To Do" -->
+<!-- Read issue: jira issue view <KEY> -->
+<!-- Post comment: jira issue comment add <KEY> --body "..." -->
+<!-- Transition: jira issue transition <KEY> "In Progress" -->
+
+<!-- === Local files (no external tracker) === -->
+<!-- List tasks: ls tasks/*.yaml -->
+<!-- Read task: cat tasks/<name>.yaml -->
+<!-- Post findings: write to tasks/<name>.research.md or tasks/<name>.review.md -->
+<!-- Track status: update tasks/state.json directly -->

--- a/template/.claude/agents/orchestrator.md
+++ b/template/.claude/agents/orchestrator.md
@@ -84,60 +84,19 @@ Blocked -> Todo -> More Research Needed -> Ready to Assign -> In Progress -> Don
 
 ## Project Context
 
-<!-- CUSTOMIZE: Update ALL of these for your project -->
-- **Repo:** `~/path/to/your-repo/`
-- **Remote URL:** `https://github.com/OWNER/REPO` <!-- or GitLab, Bitbucket, etc. -->
-- **Languages:** [your languages]
-- **Test command:** `[your test command, e.g., npm test, pytest, cargo test]`
-- **CI:** [your CI system, e.g., GitHub Actions, GitLab CI, Jenkins]
-- **Architecture docs:** `[path to architecture docs, if any]`
-- **Coding guidelines:** `CLAUDE.md` (repo root)
-- **Knowledge base:** `[path to any incident log or findings file — optional]`
-- **Worktree parent:** `~/path/to/worktrees/` (worktrees live as siblings to your repo)
-- **Default branch:** `main` <!-- CUSTOMIZE: main or master -->
+Read `.claude/agents/_project-context.md` for project details (repo path, languages, test commands, CI, worktree parent, etc.).
+
+> **Fallback:** If `_project-context.md` is missing, fill in the values directly here:
+> - **Repo:** `~/path/to/your-repo/`
+> - **Languages:** [your languages]
+> - **Test command:** `[your test command]`
+> - **Default branch:** `main`
 
 ## Tracker Commands Reference
 
-<!-- CUSTOMIZE: Uncomment the section matching your tracker and delete the rest -->
+Read `.claude/agents/_tracker-commands.md` for issue tracker CLI commands.
 
-<!-- === GitHub === -->
-<!-- List issues: gh issue list --state open --json number,title,labels --limit 50 -->
-<!-- Read issue: gh issue view <N> --comments -->
-<!-- Post comment: gh issue comment <N> --body "..." -->
-<!-- Add label: gh issue edit <N> --add-label "ready-to-assign" -->
-<!-- Remove label: gh issue edit <N> --remove-label "more-research-needed" -->
-<!-- Create label: gh label create "ready-to-merge" --color "0E8A16" --description "Reviewer recommends merge" -->
-<!-- List PRs: gh pr list --head <branch> --json number,state -->
-<!-- Check CI: gh pr checks <N> -->
-<!-- PR fields: state, mergedAt, title, body, number, headRefName, additions, deletions, files, statusCheckRollup -->
-<!-- Note: gh issue view N only shows the body. Use --comments to see research context. -->
-
-<!-- === GitLab === -->
-<!-- List issues: glab issue list --state opened -->
-<!-- Read issue: glab issue view <N> --comments -->
-<!-- Post comment: glab issue note <N> --message "..." -->
-<!-- Add label: glab issue update <N> --label "ready-to-assign" -->
-<!-- Remove label: glab issue update <N> --unlabel "more-research-needed" -->
-<!-- List MRs: glab mr list -->
-<!-- Check CI: glab ci status -->
-
-<!-- === Linear === -->
-<!-- List issues: linear issue list --team <TEAM> --status "Todo" -->
-<!-- Read issue: linear issue view <ID> -->
-<!-- Post comment: linear comment create --issue <ID> --body "..." -->
-<!-- Update status: linear issue update <ID> --status "In Progress" -->
-
-<!-- === Jira === -->
-<!-- List issues: jira issue list --project <KEY> --status "To Do" -->
-<!-- Read issue: jira issue view <KEY> -->
-<!-- Post comment: jira issue comment add <KEY> --body "..." -->
-<!-- Transition: jira issue transition <KEY> "In Progress" -->
-
-<!-- === Local files (no external tracker) === -->
-<!-- List tasks: ls tasks/*.yaml -->
-<!-- Read task: cat tasks/<name>.yaml -->
-<!-- Post findings: write to tasks/<name>.research.md or tasks/<name>.review.md -->
-<!-- Track status: update tasks/state.json directly -->
+> **Fallback:** If `_tracker-commands.md` is missing, fill in your tracker commands directly here.
 
 ---
 
@@ -207,9 +166,8 @@ mkdir -p ~/path/to/your-repo/tasks
 echo '{"tasks":{},"worktrees":{},"ready_for_human":[]}' > ~/path/to/your-repo/tasks/state.json
 touch ~/path/to/your-repo/tasks/learnings.jsonl
 
-# CUSTOMIZE: Create labels using your tracker's CLI
-# GitHub: gh label create "ready-to-merge" --color "0E8A16" --description "Reviewer recommends merge" --force
-# GitLab: glab label create "ready-to-merge" --color "#0E8A16" --description "Reviewer recommends merge"
+# CUSTOMIZE: Create the status labels listed in docs/customization-guide.md Step 3
+# Use your tracker's label creation commands from _tracker-commands.md
 ```
 
 **Step 3: Fetch open issues** (all modes):

--- a/template/.claude/agents/researcher.md
+++ b/template/.claude/agents/researcher.md
@@ -20,36 +20,18 @@ A worker agent will implement this issue after you. Your comment is the briefing
 
 ## Project Context
 
-<!-- CUSTOMIZE: Update these for your project -->
-- **Repo:** `~/path/to/your-repo/`
-- **Languages:** [your languages, e.g., TypeScript, Python, Go]
-- **Architecture docs:** `[path to architecture docs, e.g., ARCHITECTURE.md]`
-- **Coding guidelines:** `CLAUDE.md` (repo root)
-- **Knowledge base:** `[path to any incident log, findings file, or wiki — optional]`
+Read `.claude/agents/_project-context.md` for project details (repo path, languages, architecture docs, etc.).
+
+> **Fallback:** If `_project-context.md` is missing, fill in the values directly here:
+> - **Repo:** `~/path/to/your-repo/`
+> - **Languages:** [your languages]
+> - **Coding guidelines:** `CLAUDE.md` (repo root)
 
 ## Issue Tracker Commands
 
-<!-- CUSTOMIZE: Uncomment the section matching your tracker -->
+Read `.claude/agents/_tracker-commands.md` for issue tracker CLI commands.
 
-<!-- GitHub -->
-<!-- Read issue: gh issue view <number> --comments -->
-<!-- Post comment: gh issue comment <number> --body "..." -->
-
-<!-- GitLab -->
-<!-- Read issue: glab issue view <number> --comments -->
-<!-- Post comment: glab issue note <number> --message "..." -->
-
-<!-- Linear -->
-<!-- Read issue: linear issue view <ID> -->
-<!-- Post comment: linear comment create --issue <ID> --body "..." -->
-
-<!-- Jira -->
-<!-- Read issue: jira issue view <KEY> -->
-<!-- Post comment: jira issue comment add <KEY> --body "..." -->
-
-<!-- Local files (no external tracker) -->
-<!-- Read task: cat tasks/<task-name>.yaml -->
-<!-- Post findings: write to tasks/<task-name>.research.md -->
+> **Fallback:** If `_tracker-commands.md` is missing, fill in your tracker commands directly here.
 
 ## Research Workflow
 

--- a/template/.claude/agents/reviewer.md
+++ b/template/.claude/agents/reviewer.md
@@ -16,38 +16,19 @@ You are a Claude Code reviewer agent. You evaluate PRs/MRs for correctness, scop
 
 ## Project Context
 
-<!-- CUSTOMIZE: Update these for your project -->
-- **Repo:** `~/path/to/your-repo/`
-- **Languages:** [your languages]
-- **Architecture docs:** `[path to architecture docs]`
-- **Coding guidelines:** `CLAUDE.md` (repo root)
-- **Knowledge base:** `[path to any incident log or findings file — optional]`
-- **CI:** [your CI system, e.g., GitHub Actions, GitLab CI, Jenkins]
+Read `.claude/agents/_project-context.md` for project details (repo path, languages, CI system, architecture docs, etc.).
+
+> **Fallback:** If `_project-context.md` is missing, fill in the values directly here:
+> - **Repo:** `~/path/to/your-repo/`
+> - **Languages:** [your languages]
+> - **CI:** [your CI system]
+> - **Coding guidelines:** `CLAUDE.md` (repo root)
 
 ## Tracker & Code Review Commands
 
-<!-- CUSTOMIZE: Uncomment the section matching your platform -->
+Read `.claude/agents/_tracker-commands.md` for issue tracker CLI commands.
 
-<!-- GitHub -->
-<!-- Read issue: gh issue view <number> --comments -->
-<!-- Read PR diff: gh pr diff <number> -->
-<!-- Check CI: gh pr checks <number> -->
-<!-- Post verdict: gh issue comment <number> --body "..." -->
-
-<!-- GitLab -->
-<!-- Read issue: glab issue view <number> --comments -->
-<!-- Read MR diff: glab mr diff <number> -->
-<!-- Check CI: glab ci status -->
-<!-- Post verdict: glab issue note <number> --message "..." -->
-
-<!-- Bitbucket -->
-<!-- Read PR diff: git diff origin/main...HEAD -->
-<!-- Check CI: check pipeline status via REST API -->
-
-<!-- Local files (no external tracker) -->
-<!-- Read task: cat tasks/<task-name>.yaml -->
-<!-- Read diff: git diff main...HEAD -->
-<!-- Post verdict: write to tasks/<task-name>.review.md -->
+> **Fallback:** If `_tracker-commands.md` is missing, fill in your tracker commands directly here.
 
 ## Review Workflow
 

--- a/template/.claude/agents/ux-reviewer.md
+++ b/template/.claude/agents/ux-reviewer.md
@@ -17,12 +17,13 @@ You are a Claude Code UX reviewer agent. You evaluate frontend PRs through the l
 
 ## Project Context
 
-<!-- CUSTOMIZE: Update these for your project -->
-- **Repo:** `~/path/to/your-repo/`
-- **Languages:** [your languages / frameworks, e.g., React, Tailwind, Vue, CSS]
-- **Design system:** `[path to design tokens, component library, or style guide — if any]`
-- **Coding guidelines:** `CLAUDE.md` (repo root)
-- **Default branch:** `main`
+Read `.claude/agents/_project-context.md` for project details (repo path, languages, design system, default branch, etc.).
+
+> **Fallback:** If `_project-context.md` is missing, fill in the values directly here:
+> - **Repo:** `~/path/to/your-repo/`
+> - **Languages:** [your languages / frameworks]
+> - **Design system:** `[path to design tokens or style guide]`
+> - **Default branch:** `main`
 
 ## Taste Discovery
 

--- a/template/.claude/agents/worker.md
+++ b/template/.claude/agents/worker.md
@@ -24,33 +24,19 @@ You are a Claude Code worker agent implementing a scoped coding task in an isola
 
 ## Project Context
 
-<!-- CUSTOMIZE: Update these for your project -->
-- **Repo:** `~/path/to/your-repo/`
-- **Languages:** [your languages]
-- **Test command:** `[your test command, e.g., npm test, pytest, cargo test, go test ./...]`
-- **Architecture docs:** `[path to architecture docs]`
-- **Coding guidelines:** `CLAUDE.md` (repo root)
-- **Knowledge base:** `[path to any incident log or findings file — optional]`
-- **Default branch:** `main` <!-- CUSTOMIZE: main or master -->
+Read `.claude/agents/_project-context.md` for project details (repo path, languages, test commands, default branch, etc.).
+
+> **Fallback:** If `_project-context.md` is missing, fill in the values directly here:
+> - **Repo:** `~/path/to/your-repo/`
+> - **Languages:** [your languages]
+> - **Test command:** `[your test command]`
+> - **Default branch:** `main`
 
 ## Tracker & PR Commands
 
-<!-- CUSTOMIZE: Uncomment the section matching your platform -->
+Read `.claude/agents/_tracker-commands.md` for issue tracker CLI commands.
 
-<!-- GitHub -->
-<!-- Read issue: gh issue view <number> --comments -->
-<!-- Open PR: gh pr create --base main --title "..." --body "..." -->
-
-<!-- GitLab -->
-<!-- Read issue: glab issue view <number> --comments -->
-<!-- Open MR: glab mr create --target-branch main --title "..." --description "..." -->
-
-<!-- Bitbucket -->
-<!-- Open PR via REST API or Bitbucket CLI -->
-
-<!-- Local files (no external tracker) -->
-<!-- Read task: cat tasks/<task-name>.yaml -->
-<!-- Just push the branch; human opens PR manually -->
+> **Fallback:** If `_tracker-commands.md` is missing, fill in your tracker commands directly here.
 
 ## Standard Workflow
 


### PR DESCRIPTION
## Summary

- Create `_project-context.md` — single source of truth for project details (repo path, languages, test command, CI, etc.) that all 5 agents read at startup
- Create `_tracker-commands.md` — single source of truth for issue tracker CLI commands (GitHub, GitLab, Linear, Jira, local files) that all agents read at startup
- Replace duplicated inline sections in all 5 agent files with references to the shared files
- Each agent includes a fallback note so files remain usable if copied individually without the shared files
- Consolidate label creation commands in orchestrator to reference `docs/customization-guide.md` Step 3
- Update QUICKSTART.md and customization guide to reflect the new "edit once" workflow

**Before:** Users had to edit project context in 5 files and tracker commands in 4 files (same values, repeated).
**After:** Users edit `_project-context.md` once and `_tracker-commands.md` once.

## Key design decisions

- **No YAML frontmatter** on `_project-context.md` or `_tracker-commands.md` — prevents Claude Code from registering them as agents
- **Underscore prefix** (`_`) convention signals these are shared partials, not standalone agents
- **Fallback notes** in each agent file for portability — if someone copies just one agent file without the shared files, they can still fill in values directly
- **Approach A** (full extraction) chosen by the project owner over hybrid approach — the negligible startup latency from reading shared files is worth the reliability gain

## Files changed (10)

| File | Change |
|------|--------|
| `template/.claude/agents/_project-context.md` | **NEW** — shared project context |
| `template/.claude/agents/_tracker-commands.md` | **NEW** — shared tracker commands |
| `template/.claude/agents/orchestrator.md` | Replaced inline context + tracker sections with references |
| `template/.claude/agents/researcher.md` | Same |
| `template/.claude/agents/worker.md` | Same |
| `template/.claude/agents/reviewer.md` | Same |
| `template/.claude/agents/ux-reviewer.md` | Replaced inline context with reference |
| `docs/customization-guide.md` | Steps 1-2 updated to reference shared files |
| `QUICKSTART.md` | Steps 3-5 updated to reference shared files |
| `CLAUDE.md` | Repo layout updated to mention new shared files |

## How to verify

1. Confirm `_project-context.md` has no YAML frontmatter (won't be registered as an agent)
2. Confirm all 5 agent files reference `_project-context.md` and `_tracker-commands.md`
3. Confirm all 5 agent files have a fallback note
4. Confirm `_tracker-commands.md` is a superset of all tracker commands previously in individual agent files
5. Read QUICKSTART.md Steps 3-4 — verify they point to the shared files
6. Read customization-guide.md Steps 1-2 — verify they point to the shared files

## Out of scope

- The `docs/architecture.md` file references the agent file structure but doesn't need changes since it describes roles, not file internals
- The inline permissions example in `docs/customization-guide.md` Step 5 (JSON with `//` comments) is a separate concern from this refactor

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)