### PR TITLE
Add project board integration to orchestrator workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ template/              # Files users copy into their repos
     check-agents.sh    # Tmux monitor script
   tasks/
     _template.yaml     # Task YAML template
+    board-config.json  # Cached project board IDs (platform, field IDs, option IDs)
 
 examples/              # Example files showing the framework in use
   state.json           # Example mid-session state

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -76,6 +76,16 @@ gh label create "ready-to-merge" --color "0E8A16" --description "Reviewer recomm
 gh label create "human-only" --color "D93F0B" --description "Needs human input"
 ```
 
+### 5b. Set up a project board (optional but recommended)
+
+If you use a project board (GitHub Projects, GitLab Boards, Linear, or Jira), the orchestrator can update it automatically at each phase transition. This gives you a real-time Kanban view of the swarm's progress without checking the terminal.
+
+1. Create a board with columns: `Blocked`, `Todo`, `More Research Needed`, `Ready to Assign`, `In Progress`, `In Review`, `Ready to Merge`, `Done`
+2. Fill in `tasks/board-config.json` with your board's IDs (a placeholder template is included)
+3. See [Customization Guide — Step 4](docs/customization-guide.md#step-4-project-board-integration-recommended) for detailed setup instructions per platform
+
+If you skip this step, the orchestrator works fine without a board — it just won't move items between columns.
+
 ### 6. Add project-specific permissions
 
 Edit `.claude/settings.local.json` and add your test runner, linter, and any other tools agents need:

--- a/docs/customization-guide.md
+++ b/docs/customization-guide.md
@@ -134,31 +134,108 @@ Optional but recommended labels:
 - **Type:** `feature`, `bug`, `refactor`, `docs`
 - **Area:** project-specific (e.g., `area/api`, `area/frontend`, `area/auth`)
 
-## Step 4: Set Up a Project Board (Optional)
+## Step 4: Project Board Integration (Recommended)
 
-A Kanban board helps visualize the pipeline. Set up columns:
+A Kanban board gives you and the orchestrator a shared view of the pipeline. The orchestrator updates the board at every phase transition (triage, research, dispatch, review, merge). Set up columns:
 
 ```
-Blocked -> Todo -> More Research Needed -> Ready to Assign -> In Progress -> Done
+Blocked -> Todo -> More Research Needed -> Ready to Assign -> In Progress -> In Review -> Ready to Merge -> Done
 ```
 
-### GitHub Projects
+### 4a. Create or configure your board
+
+<!-- CUSTOMIZE: Follow the instructions for your platform below. -->
+
+**GitHub Projects (v2):**
 
 ```bash
-# Discover your project ID and field IDs
+# 1. Create a project (or use an existing one)
+gh project create --owner YOUR_ORG --title "My Project Board"
+
+# 2. Discover the project number and ID
 gh project list --owner YOUR_ORG --format json
+
+# 3. Discover field IDs (Status field and its option IDs)
+gh project field-list PROJECT_NUMBER --owner YOUR_ORG --format json
+
+# 4. Create a Priority field if it doesn't exist
+gh project field-create PROJECT_NUMBER --owner YOUR_ORG \
+  --name "Priority" --data-type "SINGLE_SELECT" \
+  --single-select-options "P0-critical,P1-high,P2-medium,P3-low"
+
+# 5. Re-query fields to get the Priority field ID and option IDs
 gh project field-list PROJECT_NUMBER --owner YOUR_ORG --format json
 ```
 
-Update the orchestrator with your project ID and field option IDs for moving items between columns.
+> **Note:** GitHub Projects v2 uses opaque IDs for everything — project ID, field IDs, option IDs. These must be discovered via the commands above and cached.
 
-### GitLab Boards
+**GitLab Boards:**
 
-Create a board in your GitLab project settings. Map labels to columns.
+Create a board in your GitLab project settings. Map labels to columns — each column corresponds to a label (e.g., `In Progress`, `In Review`). The orchestrator moves items by updating labels.
 
-### Linear / Jira
+**Linear:**
 
-These have built-in workflow states that serve the same purpose. Map the swarm's status labels to your existing workflow states.
+Linear has built-in workflow states. Map the swarm's columns to your team's states (e.g., "Todo" -> "Todo", "In Progress" -> "In Progress"). No extra setup needed — the orchestrator uses `linear issue update` to transition states.
+
+**Jira:**
+
+Jira has built-in workflow transitions. Map the swarm's columns to your project's statuses. The orchestrator uses `jira issue transition` to move items.
+
+### 4b. Cache board IDs in `tasks/board-config.json`
+
+To avoid re-querying the API every session, save the discovered IDs in `tasks/board-config.json`. A placeholder template is included — fill it in with your actual values:
+
+```json
+{
+  "_comment": "Cache your project board IDs here.",
+  "platform": "github",
+  "project_id": "PVT_kwHOABCDEF...",
+  "project_number": 1,
+  "owner": "your-org",
+  "status_field_id": "PVTSSF_lAHOABCDEF...",
+  "status_options": {
+    "Todo": "98765aaa",
+    "More Research Needed": "98765bbb",
+    "In Progress": "98765ccc",
+    "Ready to Assign": "98765hhh",
+    "In Review": "98765ddd",
+    "Ready to Merge": "98765eee",
+    "Blocked": "98765fff",
+    "Done": "98765ggg"
+  },
+  "priority_field_id": "PVTSSF_lAHOXYZ...",
+  "priority_options": {
+    "P0-critical": "option_id_1",
+    "P1-high": "option_id_2",
+    "P2-medium": "option_id_3",
+    "P3-low": "option_id_4"
+  },
+  "items": {}
+}
+```
+
+For **GitLab**, **Linear**, and **Jira**, you may not need opaque IDs — the orchestrator uses labels or workflow transitions directly. You can simplify the config to just `platform` and skip the ID fields, or omit the file entirely.
+
+### 4c. Verify the orchestrator can move items
+
+Test a board update manually to confirm the IDs are correct:
+
+```bash
+# GitHub Projects — move an item to "In Progress":
+gh project item-edit --project-id PVT_kwHOABCDEF... --id ITEM_ID \
+  --field-id PVTSSF_lAHOABCDEF... --single-select-option-id 98765ccc
+
+# GitLab — swap labels:
+glab issue update 42 --unlabel "Todo" --label "In Progress"
+
+# Linear:
+linear issue update ENG-123 --status "In Progress"
+
+# Jira:
+jira issue transition MYPROJ-123 "In Progress"
+```
+
+If the command succeeds, the orchestrator will be able to manage the board autonomously. If `tasks/board-config.json` is missing or still has placeholder values, the orchestrator skips board updates silently.
 
 ## Step 5: Configure Permissions
 

--- a/template/.claude/agents/orchestrator.md
+++ b/template/.claude/agents/orchestrator.md
@@ -63,14 +63,64 @@ You are an orchestrator agent running in a tmux session on a developer's machine
 
 **Board columns (if using a project board):**
 ```
-Blocked -> Todo -> More Research Needed -> Ready to Assign -> In Progress -> Done
+Blocked -> Todo -> More Research Needed -> Ready to Assign -> In Progress -> In Review -> Ready to Merge -> Done
 ```
 
-<!-- CUSTOMIZE: Commands to manage your board -->
-<!-- GitHub Projects: gh project item-edit --project-id <id> ... -->
-<!-- GitLab Boards: glab board ... or use the web UI -->
-<!-- Linear: linear issue update <ID> --status "In Progress" -->
-<!-- Jira: jira issue transition <KEY> "In Progress" -->
+### Board Management
+
+The orchestrator updates the project board at every phase transition. Board IDs are cached in `tasks/board-config.json` to avoid re-querying the API each session. See the **Board Setup** subsection under Startup for how to populate this file.
+
+**Update the board at EVERY phase transition.** Read `tasks/board-config.json` for the cached IDs. If the board-config file is missing or has placeholder values, skip board updates silently (don't fail).
+
+<!-- CUSTOMIZE: Adapt the board update commands below to your platform. Replace placeholder IDs with your actual values from tasks/board-config.json. -->
+
+**Moving an item between columns:**
+
+```bash
+# GitHub Projects (v2) — requires opaque IDs from board-config.json:
+gh project item-edit --project-id PROJECT_ID --id ITEM_ID \
+  --field-id STATUS_FIELD_ID --single-select-option-id TARGET_OPTION_ID
+
+# GitLab — uses labels mapped to board columns:
+glab issue update <N> --unlabel "In Progress" --label "In Review"
+
+# Linear:
+linear issue update ENG-123 --status "In Review"
+
+# Jira:
+jira issue transition MYPROJ-123 "In Review"
+```
+
+**Setting priority on an item:**
+
+```bash
+# GitHub Projects (v2):
+gh project item-edit --project-id PROJECT_ID --id ITEM_ID \
+  --field-id PRIORITY_FIELD_ID --single-select-option-id PRIORITY_OPTION_ID
+
+# GitLab — use priority labels:
+glab issue update <N> --label "P1-high"
+
+# Linear:
+linear issue update ENG-123 --priority "High"
+
+# Jira:
+jira issue edit MYPROJ-123 --priority "High"
+```
+
+**Phase transition → Board column mapping:**
+
+| Phase | Board Column |
+|---|---|
+| Triage: clear and ready | Todo |
+| Triage: needs research | More Research Needed |
+| Triage: needs human input | Blocked |
+| Research dispatched | More Research Needed |
+| Research complete, ready to assign | Ready to Assign |
+| Worker dispatched | In Progress |
+| PR created + review dispatched | In Review |
+| Reviewer recommends merge | Ready to Merge |
+| Human merges | Done |
 
 **Special labels the orchestrator must respect:**
 - `human-only` -> SKIP entirely. Do not triage, research, or dispatch.
@@ -169,6 +219,32 @@ touch ~/path/to/your-repo/tasks/learnings.jsonl
 # CUSTOMIZE: Create the status labels listed in docs/customization-guide.md Step 3
 # Use your tracker's label creation commands from _tracker-commands.md
 ```
+
+**Step 2b (first run only): Board setup.**
+
+If the project uses a board, discover the board IDs and cache them in `tasks/board-config.json`. This avoids re-querying the API every session.
+
+<!-- CUSTOMIZE: Run these commands for your platform to discover board IDs, then save them to tasks/board-config.json. -->
+
+```bash
+# GitHub Projects (v2) — discover project ID and field IDs:
+gh project list --owner YOUR_ORG --format json
+gh project field-list PROJECT_NUMBER --owner YOUR_ORG --format json
+
+# Create Priority field if it doesn't exist:
+gh project field-create PROJECT_NUMBER --owner YOUR_ORG \
+  --name "Priority" --data-type "SINGLE_SELECT" \
+  --single-select-options "P0-critical,P1-high,P2-medium,P3-low"
+
+# After running these commands, populate tasks/board-config.json with the
+# project_id, status_field_id, status_options, priority_field_id, and priority_options.
+
+# GitLab: Board columns are label-based. Create labels matching the column names.
+# Linear: Workflow states are built-in. Map swarm columns to your team's states.
+# Jira: Workflow transitions are built-in. Map swarm columns to your project's statuses.
+```
+
+If `tasks/board-config.json` already exists with real IDs (not placeholders), skip this step.
 
 **Step 3: Fetch open issues** (all modes):
 ```bash
@@ -271,6 +347,11 @@ For each remaining issue, decide:
 
 **DO NOT dispatch any work on issues in Blocked or labeled `human-only`.** Wait for the human to respond.
 
+**Board update after triage:** Move each triaged issue to its board column:
+- Clear and ready -> **Todo**
+- Needs research -> **More Research Needed**
+- Needs human input -> **Blocked**
+
 After triage, process issues in this order:
 1. `More Research needed` -> dispatch researchers (Phase 2)
 2. `Ready to assign` -> classify dependencies and dispatch (Phase 3+)
@@ -294,9 +375,12 @@ tmux send-keys -t swarm:researcher-01 \
 sleep 5 && tmux capture-pane -t swarm:researcher-01 -p | tail -3
 ```
 
+**Board update:** Ensure the issue is in the **More Research Needed** column when the researcher is dispatched.
+
 The researcher posts a detailed comment. When done, the orchestrator:
 - Removes `more-research-needed` label
 - Adds `ready-to-assign` label
+- **Board update:** Move the issue to **Ready to Assign**
 
 ### Phase 3: Plan & Classify
 
@@ -337,6 +421,8 @@ tmux send-keys -t swarm:worker-01 \
 # Verify agent started
 sleep 5 && tmux capture-pane -t swarm:worker-01 -p | tail -3
 ```
+
+**Board update:** Move the issue to **In Progress** when the worker is dispatched.
 
 For parallel tasks (same dependency level), dispatch to separate windows simultaneously.
 
@@ -404,12 +490,14 @@ sleep 5 && tmux capture-pane -t swarm:reviewer-01 -p | tail -3
 sleep 5 && tmux capture-pane -t swarm:ux-reviewer-01 -p | tail -3
 ```
 
+**Board update:** Move the issue to **In Review** when the reviewer is dispatched.
+
 The reviewer(s) evaluate and post comments on the issue with their recommendations.
 
-- **All dispatched reviewers recommend merge** -> label `ready-to-merge`, task status becomes `ready-for-human`
-- **Any reviewer recommends changes** -> orchestrator creates a revision task, re-dispatches worker
+- **All dispatched reviewers recommend merge** -> label `ready-to-merge`, task status becomes `ready-for-human`. **Board update:** Move to **Ready to Merge**.
+- **Any reviewer recommends changes** -> orchestrator creates a revision task, re-dispatches worker. **Board update:** Move back to **In Progress**.
 - **UX reviewer requests screenshots** -> post a comment tagging the human, wait for screenshots, then the UX reviewer continues
-- **3 failed revision cycles** -> label `human-only`, move to Blocked, post comment explaining what failed
+- **3 failed revision cycles** -> label `human-only`, move to Blocked, post comment explaining what failed. **Board update:** Move to **Blocked**.
 
 ### Phase 7: Ready for Human
 
@@ -437,6 +525,8 @@ osascript -e 'display notification "Issue #42 ready to merge — check your trac
 ```
 
 ### Phase 8: Post-Merge Cleanup (After Human Merges)
+
+**Board update:** Move merged issues to **Done**.
 
 After the human merges PRs/MRs:
 
@@ -556,26 +646,26 @@ Orchestrator:
 
   Triage:
     #47: Bug: API timeout on large payloads — P0-critical, clear
-          -> labeled ready-to-assign
+          -> labeled ready-to-assign, board: Todo
     #51: Add rate limiting — P1-high, labeled more-research-needed
-          -> stays in More Research Needed
+          -> board: More Research Needed
     #52: Upgrade dependencies — P2-medium, ready-to-assign
-          -> stays in Ready to Assign (lower priority)
+          -> board: Todo (lower priority)
 
   Phase: Research (P1-high)
     -> Researcher-01 investigating #51...
     [4 min] Research comment posted
-    -> #51 moved to Ready to Assign
+    -> #51 labeled ready-to-assign, board: Ready to Assign
 
   Phase: Dispatch (P0 first)
-    -> worker-01: #47 P0-critical bug (API timeout) — moved to In Progress
-    -> worker-02: #51 P1-high feature (rate limiting) — moved to In Progress
+    -> worker-01: #47 P0-critical bug (API timeout), board: In Progress
+    -> worker-02: #51 P1-high feature (rate limiting), board: In Progress
 
   Monitoring...
     [8 min] PR #60 opened for #47, CI running...
-    [10 min] CI green. Dispatching reviewer...
+    [10 min] CI green. Dispatching reviewer, board: In Review
     [12 min] Reviewer recommends merge
-    -> #47 labeled ready-to-merge
+    -> #47 labeled ready-to-merge, board: Ready to Merge
     -> Posted summary on #47
     -> Desktop notification: "P0 bug #47 ready to merge"
 
@@ -583,7 +673,7 @@ Orchestrator:
 
   Post-merge:
     Main updated, tests green
-    Worktree cleaned up, #47 moved to Done
+    Worktree cleaned up, board: #47 -> Done
     -> Dispatching next: worker-01 picks up #52 (P2-medium)
 
   Writing HANDOFF.md...

--- a/template/tasks/board-config.json
+++ b/template/tasks/board-config.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "Cache your project board IDs here so the orchestrator doesn't re-query the API every session. Run the discovery commands in customization-guide.md Step 4 to fill these in.",
+  "platform": "github",
+  "project_id": "YOUR_PROJECT_ID",
+  "project_number": 1,
+  "owner": "YOUR_ORG_OR_USER",
+  "status_field_id": "YOUR_STATUS_FIELD_ID",
+  "status_options": {
+    "Todo": "OPTION_ID",
+    "More Research Needed": "OPTION_ID",
+    "In Progress": "OPTION_ID",
+    "Ready to Assign": "OPTION_ID",
+    "In Review": "OPTION_ID",
+    "Ready to Merge": "OPTION_ID",
+    "Blocked": "OPTION_ID",
+    "Done": "OPTION_ID"
+  },
+  "priority_field_id": "YOUR_PRIORITY_FIELD_ID",
+  "priority_options": {
+    "P0-critical": "OPTION_ID",
+    "P1-high": "OPTION_ID",
+    "P2-medium": "OPTION_ID",
+    "P3-low": "OPTION_ID"
+  },
+  "items": {}
+}


### PR DESCRIPTION
## Summary

- **Orchestrator template** (`template/.claude/agents/orchestrator.md`): Replaced commented-out board placeholders with active Board Management section including multi-platform commands, phase-transition-to-column mapping table, priority field management, Board Setup startup subsection, and board update instructions at every phase (Triage, Research, Dispatch Workers, Review, Ready for Human, Post-Merge Cleanup). Updated the example session to show board column moves.
- **New file** `template/tasks/board-config.json`: Placeholder template for caching project board IDs (project ID, status field/options, priority field/options) so the orchestrator doesn't re-query the API each session.
- **Customization guide** (`docs/customization-guide.md`): Expanded Step 4 from a brief "Optional" section into a detailed "Project Board Integration (Recommended)" walkthrough with sub-steps for creating/configuring the board, caching IDs, and verifying the setup — with platform-specific instructions for GitHub Projects, GitLab, Linear, and Jira.
- **QUICKSTART.md**: Added Step 5b for optional board setup after label creation, with a link to the detailed customization guide.
- **CLAUDE.md**: Updated repo layout to mention `tasks/board-config.json`.

All board commands are behind `<!-- CUSTOMIZE -->` markers with examples for GitHub Projects, GitLab, Linear, and Jira.

Fixes #13

## How to verify

1. Read `template/.claude/agents/orchestrator.md` — confirm board update instructions appear at each phase transition
2. Validate JSON: `python3 -m json.tool template/tasks/board-config.json`
3. Read `docs/customization-guide.md` Step 4 — confirm the detailed board integration walkthrough
4. Read `QUICKSTART.md` — confirm Step 5b mentions board setup
5. Read `CLAUDE.md` — confirm `board-config.json` appears in repo layout


🤖 Generated with [Claude Code](https://claude.com/claude-code)