### PR TITLE
Ignore entire tasks/ directory in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,4 @@
 .DS_Store
 
 # Ephemeral swarm state (regenerated each session)
-tasks/HANDOFF.md
-
-# Suggested additions for your target repo's .gitignore:
-# tasks/state.json
-# tasks/learnings.jsonl
-# tasks/HANDOFF.md
+tasks/


### PR DESCRIPTION
## Summary
- Replaces the partial `tasks/HANDOFF.md` ignore with a blanket `tasks/` ignore
- All files in that directory are ephemeral runtime artifacts from the orchestrator (state.json, learnings.jsonl, task YAMLs, board-config.json)

## Test plan
- [x] `git status` no longer shows untracked `tasks/` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)